### PR TITLE
fix the issue of failing to download pkg

### DIFF
--- a/seafile-server-centos-7-amd64-http
+++ b/seafile-server-centos-7-amd64-http
@@ -114,7 +114,7 @@ if is_pro; then
     INSTALLPATH=/opt/seafile/seafile-pro-server-${SEAFILE_VERSION}/
 else
     SEAFILE_SERVER_PACKAGE=seafile-server_${SEAFILE_VERSION}_x86-64.tar.gz
-    SEAFILE_SERVER_PACKAGE_URL=http://download-cn.seafile.com/${SEAFILE_SERVER_PACKAGE}
+    SEAFILE_SERVER_PACKAGE_URL=http://seafile-downloads.oss-cn-shanghai.aliyuncs.com/${SEAFILE_SERVER_PACKAGE}
     INSTALLPATH=/opt/seafile/seafile-server-${SEAFILE_VERSION}/
 fi
 

--- a/seafile-server-ubuntu-16-04-amd64-http
+++ b/seafile-server-ubuntu-16-04-amd64-http
@@ -115,7 +115,7 @@ if is_pro; then
     INSTALLPATH=/opt/seafile/seafile-pro-server-${SEAFILE_VERSION}/
 else
     SEAFILE_SERVER_PACKAGE=seafile-server_${SEAFILE_VERSION}_x86-64.tar.gz
-    SEAFILE_SERVER_PACKAGE_URL=http://download-cn.seafile.com/${SEAFILE_SERVER_PACKAGE}
+    SEAFILE_SERVER_PACKAGE_URL=http://seafile-downloads.oss-cn-shanghai.aliyuncs.com/${SEAFILE_SERVER_PACKAGE}
     INSTALLPATH=/opt/seafile/seafile-server-${SEAFILE_VERSION}/
 fi
 


### PR DESCRIPTION
The script downloads a wrong package from an invalid URL, and the tar instruction failed. The patch fixes this issue.